### PR TITLE
[GLOW-2563] docs: correct margin-account rent 0.072 -> 0.055 SOL

### DIFF
--- a/src/01-Overview/user-journey.md
+++ b/src/01-Overview/user-journey.md
@@ -24,7 +24,7 @@ This journey showcases how a user can utilize Glow’s capabilities efficiently 
 
 ## 1. Connecting the Wallet and Setting Up a Margin Account
 
-The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must pay a small refundable rent fee of 0.0534 SOL to cover on-chain storage costs on the Solana blockchain. Glow transparently displays this requirement to the user through a clear prompt.
+The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must pay a small refundable rent fee of 0.055 SOL to cover on-chain storage costs on the Solana blockchain. Glow transparently displays this requirement to the user through a clear prompt.
 
 Glow enables users to create and manage multiple margin accounts under a single wallet, providing an intuitive interface that allows seamless navigation, management, and transactions across all accounts.
 

--- a/src/01-Overview/user-journey.md
+++ b/src/01-Overview/user-journey.md
@@ -24,7 +24,7 @@ This journey showcases how a user can utilize Glow’s capabilities efficiently 
 
 ## 1. Connecting the Wallet and Setting Up a Margin Account
 
-The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must pay a small refundable rent fee of 0.072 SOL to cover on-chain storage costs on the Solana blockchain. Glow transparently displays this requirement to the user through a clear prompt.
+The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must provide a small, refundable rent deposit of ~0.0534 SOL to cover on-chain storage costs on the Solana blockchain (a total of ~0.06 SOL is required, which also covers one-time setup and network fees). Glow transparently displays this requirement to the user through a clear prompt.
 
 Glow enables users to create and manage multiple margin accounts under a single wallet, providing an intuitive interface that allows seamless navigation, management, and transactions across all accounts.
 

--- a/src/01-Overview/user-journey.md
+++ b/src/01-Overview/user-journey.md
@@ -24,7 +24,7 @@ This journey showcases how a user can utilize Glow’s capabilities efficiently 
 
 ## 1. Connecting the Wallet and Setting Up a Margin Account
 
-The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must provide a small, refundable rent deposit of ~0.0534 SOL to cover on-chain storage costs on the Solana blockchain (a total of ~0.06 SOL is required, which also covers one-time setup and network fees). Glow transparently displays this requirement to the user through a clear prompt.
+The journey starts when the user connects their wallet to Glow. The user is prompted to create a margin account, a crucial step since this account enables access to various features like depositing assets and borrowing. To set up this account, the user must pay a small refundable rent fee of 0.0534 SOL to cover on-chain storage costs on the Solana blockchain. Glow transparently displays this requirement to the user through a clear prompt.
 
 Glow enables users to create and manage multiple margin accounts under a single wallet, providing an intuitive interface that allows seamless navigation, management, and transactions across all accounts.
 

--- a/src/03-margin-accounts/how-to-close-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-close-a-margin-account.md
@@ -67,7 +67,7 @@ If you dismiss the modal or don't sign the second transaction, you can resume wh
 
 ## Step 4: Confirmation
 
-Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your SOL rent deposit (0.0534 SOL) will be refunded to your wallet, and the account will be removed from your Portfolio.
+Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your SOL rent deposit (0.055 SOL) will be refunded to your wallet, and the account will be removed from your Portfolio.
 
 <img
 src="/img/close-success.png"

--- a/src/03-margin-accounts/how-to-close-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-close-a-margin-account.md
@@ -67,7 +67,7 @@ If you dismiss the modal or don't sign the second transaction, you can resume wh
 
 ## Step 4: Confirmation
 
-Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your refundable rent deposit (**~0.0534 SOL** for the margin account, plus any lookup-table rent reclaimed during the first transaction) will be returned to your wallet, and the account will be removed from your Portfolio. Note that network fees paid while using the account are not refundable.
+Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your SOL rent deposit (0.0534 SOL) will be refunded to your wallet, and the account will be removed from your Portfolio.
 
 <img
 src="/img/close-success.png"

--- a/src/03-margin-accounts/how-to-close-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-close-a-margin-account.md
@@ -67,7 +67,7 @@ If you dismiss the modal or don't sign the second transaction, you can resume wh
 
 ## Step 4: Confirmation
 
-Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your SOL rent deposit (0.072 SOL) will be refunded to your wallet, and the account will be removed from your Portfolio.
+Once the closure transaction is confirmed, a **"Margin account closed successfully"** snackbar will appear at the top of the screen. Your refundable rent deposit (**~0.0534 SOL** for the margin account, plus any lookup-table rent reclaimed during the first transaction) will be returned to your wallet, and the account will be removed from your Portfolio. Note that network fees paid while using the account are not refundable.
 
 <img
 src="/img/close-success.png"

--- a/src/03-margin-accounts/how-to-create-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-create-a-margin-account.md
@@ -23,7 +23,7 @@ Glow even supports creating multiple margin accounts under a single wallet, thus
 ## Prerequisites
 
 1. **Wallet Connection**: Ensure your wallet (Phantom, Backpack, Solflare, WalletConnect, or Coinbase Wallet) is connected to the Glow platform. Glow supports multiple wallets for seamless integration.
-2. **SOL Balance Requirement**: You must have at least **0.072 SOL** in your wallet to cover the one-time, refundable rent fee required by Solana for on-chain storage. You can close a margin account from the Portfolio page and receive the full rent fee back to your wallet.
+2. **SOL Balance Requirement**: You must have at least **~0.06 SOL** in your wallet to create a margin account. Most of this is a **refundable rent deposit of ~0.0534 SOL** required by Solana for on-chain storage — you receive it back in full when you close the account from the Portfolio page. The small remainder covers one-time lookup-table setup and network fees, which are not refundable.
 3. **Multiple Accounts = Additional Rent Fees**: Each additional margin account requires an additional rent fee.
 
 :::tip
@@ -33,7 +33,7 @@ The rent fee does not cover SOL needed for transaction processing. Transaction f
 ## Key Visual Indicators
 
 - **Tooltips**: If no margin account exists, tooltips on actions like Deposit, Withdraw, Borrow, or Repay buttons will display "Create a margin account first."
-- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than 0.072 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
+- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than ~0.06 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
 
 ## Step 1: Connect Your Wallet
 
@@ -67,8 +67,8 @@ Once your wallet is connected:
 
 In the **New Margin Account** modal:
 
-- You'll see the account name (e.g. "Account #1") and a **one-time rent** of **0.072 SOL**.
-- The modal explains that this rent fee is required by Solana and is fully refundable when you close the account.
+- You'll see the account name (e.g. "Account #1") and the **refundable rent fee** of **~0.0534 SOL**.
+- The modal explains that this rent fee is required by Solana and is fully refundable when you close the account. Creating the account costs slightly more overall (~0.06 SOL) because of one-time lookup-table setup and network fees, which are not refundable.
 - Click **Create Margin Account** to proceed. Glow will handle the full setup automatically — you'll need to approve two quick wallet transactions in sequence.
 
 <img
@@ -77,7 +77,7 @@ style={{ maxWidth: "400px", width: "100%", height: "auto", display: "block", mar
 />
 
 :::tip Handle Insufficient SOL Balance
-If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **0.072 SOL** plus a small amount for transaction fees.
+If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **~0.06 SOL** — the refundable rent deposit (~0.0534 SOL) plus a small amount for lookup-table setup and transaction fees.
 :::
 
 ## Step 4: Confirmation

--- a/src/03-margin-accounts/how-to-create-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-create-a-margin-account.md
@@ -23,7 +23,7 @@ Glow even supports creating multiple margin accounts under a single wallet, thus
 ## Prerequisites
 
 1. **Wallet Connection**: Ensure your wallet (Phantom, Backpack, Solflare, WalletConnect, or Coinbase Wallet) is connected to the Glow platform. Glow supports multiple wallets for seamless integration.
-2. **SOL Balance Requirement**: You must have at least **~0.06 SOL** in your wallet to create a margin account. Most of this is a **refundable rent deposit of ~0.0534 SOL** required by Solana for on-chain storage — you receive it back in full when you close the account from the Portfolio page. The small remainder covers one-time lookup-table setup and network fees, which are not refundable.
+2. **SOL Balance Requirement**: You must have at least **0.0534 SOL** in your wallet to cover the one-time, refundable rent fee required by Solana for on-chain storage. You can close a margin account from the Portfolio page and receive the full rent fee back to your wallet.
 3. **Multiple Accounts = Additional Rent Fees**: Each additional margin account requires an additional rent fee.
 
 :::tip
@@ -33,7 +33,7 @@ The rent fee does not cover SOL needed for transaction processing. Transaction f
 ## Key Visual Indicators
 
 - **Tooltips**: If no margin account exists, tooltips on actions like Deposit, Withdraw, Borrow, or Repay buttons will display "Create a margin account first."
-- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than ~0.06 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
+- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than 0.0534 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
 
 ## Step 1: Connect Your Wallet
 
@@ -67,8 +67,8 @@ Once your wallet is connected:
 
 In the **New Margin Account** modal:
 
-- You'll see the account name (e.g. "Account #1") and the **refundable rent fee** of **~0.0534 SOL**.
-- The modal explains that this rent fee is required by Solana and is fully refundable when you close the account. Creating the account costs slightly more overall (~0.06 SOL) because of one-time lookup-table setup and network fees, which are not refundable.
+- You'll see the account name (e.g. "Account #1") and a **one-time rent** of **0.0534 SOL**.
+- The modal explains that this rent fee is required by Solana and is fully refundable when you close the account.
 - Click **Create Margin Account** to proceed. Glow will handle the full setup automatically — you'll need to approve two quick wallet transactions in sequence.
 
 <img
@@ -77,7 +77,7 @@ style={{ maxWidth: "400px", width: "100%", height: "auto", display: "block", mar
 />
 
 :::tip Handle Insufficient SOL Balance
-If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **~0.06 SOL** — the refundable rent deposit (~0.0534 SOL) plus a small amount for lookup-table setup and transaction fees.
+If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **0.0534 SOL** plus a small amount for transaction fees.
 :::
 
 ## Step 4: Confirmation

--- a/src/03-margin-accounts/how-to-create-a-margin-account.md
+++ b/src/03-margin-accounts/how-to-create-a-margin-account.md
@@ -23,7 +23,7 @@ Glow even supports creating multiple margin accounts under a single wallet, thus
 ## Prerequisites
 
 1. **Wallet Connection**: Ensure your wallet (Phantom, Backpack, Solflare, WalletConnect, or Coinbase Wallet) is connected to the Glow platform. Glow supports multiple wallets for seamless integration.
-2. **SOL Balance Requirement**: You must have at least **0.0534 SOL** in your wallet to cover the one-time, refundable rent fee required by Solana for on-chain storage. You can close a margin account from the Portfolio page and receive the full rent fee back to your wallet.
+2. **SOL Balance Requirement**: You must have at least **0.055 SOL** in your wallet to cover the one-time, refundable rent fee required by Solana for on-chain storage. You can close a margin account from the Portfolio page and receive the full rent fee back to your wallet.
 3. **Multiple Accounts = Additional Rent Fees**: Each additional margin account requires an additional rent fee.
 
 :::tip
@@ -33,7 +33,7 @@ The rent fee does not cover SOL needed for transaction processing. Transaction f
 ## Key Visual Indicators
 
 - **Tooltips**: If no margin account exists, tooltips on actions like Deposit, Withdraw, Borrow, or Repay buttons will display "Create a margin account first."
-- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than 0.0534 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
+- **Disabled Buttons**: If the wallet is not connected or has insufficient SOL, action buttons will be disabled. For instance, if your wallet balance is less than 0.055 SOL, the modal for creating a margin account will indicate that the required balance is insufficient, and you will need to top up your wallet to continue.
 
 ## Step 1: Connect Your Wallet
 
@@ -67,7 +67,7 @@ Once your wallet is connected:
 
 In the **New Margin Account** modal:
 
-- You'll see the account name (e.g. "Account #1") and a **one-time rent** of **0.0534 SOL**.
+- You'll see the account name (e.g. "Account #1") and a **one-time rent** of **0.055 SOL**.
 - The modal explains that this rent fee is required by Solana and is fully refundable when you close the account.
 - Click **Create Margin Account** to proceed. Glow will handle the full setup automatically — you'll need to approve two quick wallet transactions in sequence.
 
@@ -77,7 +77,7 @@ style={{ maxWidth: "400px", width: "100%", height: "auto", display: "block", mar
 />
 
 :::tip Handle Insufficient SOL Balance
-If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **0.0534 SOL** plus a small amount for transaction fees.
+If you don't have enough SOL, the **Create Margin Account** button will be disabled and an error message will prompt you to add more SOL. You'll need at least **0.055 SOL** plus a small amount for transaction fees.
 :::
 
 ## Step 4: Confirmation


### PR DESCRIPTION
## Summary

The docs stated **0.072 SOL** as the margin-account rent — including the close page, which promised the full 0.072 back on close. The actual rent is **~0.055 SOL**, so users were seeing/expecting more than the real amount.

Minimal change: replace the stated rent figure with **0.055 SOL**, keeping the original wording. Matches the app value (companion PR: Blueprint-Finance/glow-v1#3720).

Jira: GLOW-2563

## Changes
- `03-margin-accounts/how-to-create-a-margin-account.md` — 0.072 → 0.055 SOL
- `03-margin-accounts/how-to-close-a-margin-account.md` — 0.072 → 0.055 SOL
- `01-Overview/user-journey.md` — 0.072 → 0.055 SOL

## Test plan
- [ ] `yarn build` / docusaurus build passes
- [ ] Prose reads correctly on the Create and Close pages