### PR TITLE
docs: correct Redstone oracle audit date to July 13, 2026

### DIFF
--- a/src/audits.md
+++ b/src/audits.md
@@ -14,7 +14,7 @@ Below, you can find the latest Glow Audit Reports from industry-leading Web3 sec
 ## Redstone Oracle Integration Audit
 
 - **Auditor:** Halborn
-- **Date:** July 10, 2026
+- **Date:** July 13, 2026
 - [View Full Audit Report](/files/Redstone-Oracle-Integration-Audit-SSC.pdf)
 
 ## Glow Vault: Transferrable Tokens & Epoch Withdrawal


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only date correction on the audits page with no product or security logic changes.
> 
> **Overview**
> Updates the **Redstone Oracle Integration Audit** entry on the Audits page so the listed **Date** is **July 13, 2026** instead of July 10, 2026. No other audit listings or links change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea14695bf185b6bc2302ad0c5e46c6e365d2a26e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->